### PR TITLE
누락된 API 버저닝 추가

### DIFF
--- a/src/main/kotlin/com/iplease/server/ip/release/domain/reserve/controller/IpReleaseReserveController.kt
+++ b/src/main/kotlin/com/iplease/server/ip/release/domain/reserve/controller/IpReleaseReserveController.kt
@@ -16,7 +16,7 @@ import reactor.core.publisher.Mono
 import java.time.LocalDate
 
 @RestController
-@RequestMapping("/ip/release/reserve")
+@RequestMapping("/api/v1/ip/release/reserve")
 class IpReleaseReserveController(
     private val ipReleaseReserveService: IpReleaseReserveService,
     private val policyCheckService: PolicyCheckService,


### PR DESCRIPTION
기존 할당IP 해제예약 API 에서 누락된 api 버저닝 표기`/api/v1`를 추가하였습니다.